### PR TITLE
Enable config to disable debug

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,8 +11,8 @@ module.exports = function (options) {
 
   return function (data, args, callback) {
     //console.log(JSON.stringify(args, null, 4));
-
-    var b = browserify({ debug: true });
+    var debug = (args.debug && args.debug === true) ? true : false;
+    var b = browserify({ debug: debug });
 
     //load transforms if specified
     if (options.transform) {

--- a/index.js
+++ b/index.js
@@ -11,8 +11,10 @@ module.exports = function (options) {
 
   return function (data, args, callback) {
     //console.log(JSON.stringify(args, null, 4));
-    var debug = (args.debug && args.debug === true) ? true : false;
-    var b = browserify({ debug: debug });
+    var browserifyOptions = (args.browserifyOptions) ? args.browserifyOptions : {};
+    browserifyOptions.debug = (browserifyOptions.debug === true) ? true : false;
+
+    var b = browserify(browserifyOptions);
 
     //load transforms if specified
     if (options.transform) {


### PR DESCRIPTION
In dev mode our javascript is entirely un-minified. So having the filesize balloon with the map data simply slows things down.
